### PR TITLE
refactor menu structure and enhance UI elements for consistency

### DIFF
--- a/assets/styles/styles.qss
+++ b/assets/styles/styles.qss
@@ -6,12 +6,11 @@ QWidget#MainWindow, QDialog#SettingsDialog, QDialog#WordEditorDialog, QDialog#Ab
     color: #f3f3f3;
     border-radius: 8px;
     border: 1px solid #2d2d2d;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
 }
 
 /* Labels */
 QLabel#SettingsLabel, QLabel#titleLabel, QLabel#InstructionLabel {
-    font-family: "Segoe UI Variable", "Segoe UI", Arial, sans-serif;
+    font-family: "Segoe UI", Arial, sans-serif;
     font-size: 15px;
     font-weight: 600; /* Semibold */
     color: #f3f3f3;
@@ -19,40 +18,40 @@ QLabel#SettingsLabel, QLabel#titleLabel, QLabel#InstructionLabel {
 }
 
 QLabel#SettingsDescription, QLabel#StatusLabel, QLabel#SummaryLabel, QLabel#AboutVersionLabel {
-    font-family: "Segoe UI Variable", "Segoe UI", Arial, sans-serif;
+    font-family: "Segoe UI", Arial, sans-serif;
     font-size: 13px;
     color: #d1d1d1;
     padding: 4px;
 }
 
 QLabel#AboutNameLabel {
-    font-family: "Segoe UI Variable", "Segoe UI", Arial, sans-serif;
+    font-family: "Segoe UI", Arial, sans-serif;
     font-size: 20px;
     font-weight: 600;
     color: #f3f3f3;
 }
 
 QLabel#SplashAppName {
-    font-family: "Segoe UI Variable", "Segoe UI", Arial, sans-serif;
+    font-family: "Segoe UI", Arial, sans-serif;
     font-size: 28px;
     font-weight: 600;
     color: #f3f3f3;
 }
 
 QLabel#SplashSlogan {
-    font-family: "Segoe UI Variable", "Segoe UI", Arial, sans-serif;
+    font-family: "Segoe UI", Arial, sans-serif;
     font-size: 16px;
     color: #d1d1d1;
 }
 
 QLabel#SplashVersion {
-    font-family: "Segoe UI Variable", "Segoe UI", Arial, sans-serif;
+    font-family: "Segoe UI", Arial, sans-serif;
     font-size: 12px;
     color: #797979;
 }
 
 QLabel#SplashMessage {
-    font-family: "Segoe UI Variable", "Segoe UI", Arial, sans-serif;
+    font-family: "Segoe UI", Arial, sans-serif;
     font-size: 12px;
     color: #d1d1d1;
 }
@@ -65,7 +64,7 @@ QComboBox#SettingsComboBox {
     border-radius: 4px;
     padding: 4px 8px;
     min-height: 32px;
-    font-family: "Segoe UI Variable", "Segoe UI", Arial, sans-serif;
+    font-family: "Segoe UI", Arial, sans-serif;
     font-size: 13px;
 }
 
@@ -88,7 +87,7 @@ QLineEdit#SettingsLineEdit {
     border-radius: 4px;
     padding: 4px 8px;
     min-height: 32px;
-    font-family: "Segoe UI Variable", "Segoe UI", Arial, sans-serif;
+    font-family: "Segoe UI", Arial, sans-serif;
     font-size: 13px;
 }
 
@@ -105,7 +104,7 @@ QLineEdit#SettingsLineEdit:disabled {
 /* Checkboxes */
 QCheckBox#SettingsCheckBox {
     color: #f3f3f3;
-    font-family: "Segoe UI Variable", "Segoe UI", Arial, sans-serif;
+    font-family: "Segoe UI", Arial, sans-serif;
     font-size: 13px;
     padding: 8px;
 }
@@ -130,7 +129,7 @@ QCheckBox#SettingsCheckBox::indicator:hover {
 /* Status Label */
 QLabel#SettingsStatusLabel {
     color: #107c10; /* Windows 11 green for success */
-    font-family: "Segoe UI Variable", "Segoe UI", Arial, sans-serif;
+    font-family: "Segoe UI", Arial, sans-serif;
     font-size: 13px;
     padding: 8px;
 }
@@ -152,32 +151,18 @@ QDialogButtonBox#SummaryButtonBox QPushButton {
     border: 1px solid #585858;
     min-height: 32px;
     max-width: 120px; /* Reduced width for dialog buttons */
-    font-family: "Segoe UI Variable", "Segoe UI", Arial, sans-serif;
+    font-family: "Segoe UI", Arial, sans-serif;
     font-size: 13px;
     padding: 4px 8px;
     border-radius: 4px;
     margin-right: 8px; /* Gap between dialog buttons */
-    transition: background-color 0.2s ease-in-out;
-}
-
-QDialogButtonBox#SettingsButtonBox QPushButton:hover,
-QDialogButtonBox#AboutButtonBox QPushButton:hover,
-QDialogButtonBox#SummaryButtonBox QPushButton:hover {
-    background-color: #3c3c3c;
-    border-color: #aaaaaa;
-}
-
-QDialogButtonBox#SettingsButtonBox QPushButton:focus,
-QDialogButtonBox#AboutButtonBox QPushButton:focus,
-QDialogButtonBox#SummaryButtonBox QPushButton:focus {
-    border: 2px solid #0078d4;
 }
 
 /* Menu Bar */
 QMenuBar#MenuBar {
     background-color: #333333;
     color: #f3f3f3;
-    font-family: "Segoe UI Variable", "Segoe UI", Arial, sans-serif;
+    font-family: "Segoe UI", Arial, sans-serif;
     font-size: 13px;
     padding: 4px;
     min-height: 32px;
@@ -194,7 +179,7 @@ QListWidget#FileList {
     border: 1px solid #585858;
     border-radius: 4px;
     padding: 4px;
-    font-family: "Segoe UI Variable", "Segoe UI", Arial, sans-serif;
+    font-family: "Segoe UI", Arial, sans-serif;
     font-size: 13px;
 }
 
@@ -218,10 +203,9 @@ QProgressBar#SplashProgressBar, QProgressBar#TranscriptionProgressBar {
     border-radius: 4px;
     background-color: #333333;
     min-height: 4px;
-    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
     text-align: center;
     color: #f3f3f3;
-    font-family: "Segoe UI Variable", "Segoe UI", Arial, sans-serif;
+    font-family: "Segoe UI", Arial, sans-serif;
     font-size: 10px;
 }
 
@@ -234,7 +218,7 @@ QProgressBar#SplashProgressBar::chunk, QProgressBar#TranscriptionProgressBar::ch
 #StatusBar {
     background: qlineargradient(x1:1, y1:0, x2:0, y2:0, stop:0 #3c3c3c, stop:1 #252525); /* Adjusted gradient */
     color: #f3f3f3;
-    font-family: "Segoe UI Variable", "Segoe UI", Arial, sans-serif;
+    font-family: "Segoe UI", Arial, sans-serif;
     font-size: 10px;
     min-height: 24px;
 }
@@ -254,12 +238,11 @@ QPushButton#PrimaryButton {
     border: none;
     min-height: 32px;
     max-width: 150px; /* Confirmed width */
-    font-family: "Segoe UI Variable", "Segoe UI", Arial, sans-serif;
+    font-family: "Segoe UI", Arial, sans-serif;
     font-size: 13px;
     padding: 4px 8px;
     border-radius: 4px;
     margin-right: 8px; /* Gap between buttons */
-    transition: background-color 0.2s ease-in-out;
 }
 
 QPushButton#PrimaryButton:hover {
@@ -281,12 +264,11 @@ QPushButton#DangerButton, QPushButton#WordEditorButton[role="danger"] {
     border: none;
     min-height: 32px;
     max-width: 150px; /* Confirmed width */
-    font-family: "Segoe UI Variable", "Segoe UI", Arial, sans-serif;
+    font-family: "Segoe UI", Arial, sans-serif;
     font-size: 13px;
     padding: 4px 8px;
     border-radius: 4px;
     margin-right: 8px; /* Gap between buttons */
-    transition: background-color 0.2s ease-in-out;
 }
 
 QPushButton#DangerButton:hover, QPushButton#WordEditorButton[role="danger"]:hover {
@@ -308,12 +290,11 @@ QPushButton#SettingsButton, QPushButton#WordEditorButton {
     border: 1px solid #585858;
     min-height: 32px;
     max-width: 150px; /* Confirmed width */
-    font-family: "Segoe UI Variable", "Segoe UI", Arial, sans-serif;
+    font-family: "Segoe UI", Arial, sans-serif;
     font-size: 13px;
     padding: 4px 8px;
     border-radius: 4px;
     margin-right: 8px; /* Gap between buttons */
-    transition: background-color 0.2s ease-in-out;
 }
 
 QPushButton#SettingsButton:hover, QPushButton#WordEditorButton:hover {

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -188,11 +188,13 @@ class MainWindow(QWidget):
             # Initialize menu bar
             menu_bar = QMenuBar(self)
             menu_bar.setObjectName("MenuBar")
+
+            # Arquivo menu
             file_menu = menu_bar.addMenu("Arquivo")
-            open_file_action = QAction(QIcon("assets/icons/audio_file.png"), "Selecionar Arquivo", self)
+            open_file_action = QAction(QIcon("assets/icons/audio_file.png"), "Selecionar Arquivo...", self)
             open_file_action.triggered.connect(self.select_file)
             file_menu.addAction(open_file_action)
-            open_folder_action = QAction(QIcon("assets/icons/library_music.png"), "Selecionar Pasta", self)
+            open_folder_action = QAction(QIcon("assets/icons/library_music.png"), "Selecionar Pasta...", self)
             open_folder_action.triggered.connect(self.select_folder)
             file_menu.addAction(open_folder_action)
             file_menu.addSeparator()
@@ -200,30 +202,35 @@ class MainWindow(QWidget):
             exit_action.triggered.connect(self.close)
             file_menu.addAction(exit_action)
 
-            tools_menu = menu_bar.addMenu("Ferramentas")
-            edit_words_action = QAction(QIcon("assets/icons/edit.png"), "Editar Palavras Sensíveis", self)
+            # Editar menu
+            edit_menu = menu_bar.addMenu("Editar")
+            edit_words_action = QAction(QIcon("assets/icons/edit.png"), "Editar Palavras Sensíveis...", self)
             edit_words_action.triggered.connect(self.open_word_editor)
-            tools_menu.addAction(edit_words_action)
-            open_log_action = QAction(QIcon("assets/icons/bug_report.png"), "Abrir Log", self)
-            open_log_action.triggered.connect(self.open_log_file)
-            tools_menu.addAction(open_log_action)
-            backup_transcriptions_action = QAction(QIcon("assets/icons/backup.png"), "Fazer Backup das Transcrições", self)
+            edit_menu.addAction(edit_words_action)
+
+            # Ferramentas menu
+            tools_menu = menu_bar.addMenu("Ferramentas")
+            backup_transcriptions_action = QAction(QIcon("assets/icons/backup.png"), u"Fazer Backup das Transcrições...", self)
             backup_transcriptions_action.triggered.connect(self.backup_transcriptions)
             tools_menu.addAction(backup_transcriptions_action)
-
-            settings_menu = menu_bar.addMenu("Configurações")
-            settings_action = QAction(QIcon("assets/icons/settings.png"), "Configurações", self)
+            open_log_action = QAction(QIcon("assets/icons/bug_report.png"), u"Abrir Log", self)
+            open_log_action.triggered.connect(self.open_log_file)
+            tools_menu.addAction(open_log_action)
+            settings_action = QAction(QIcon("assets/icons/settings.png"), u"Opções...", self)
             settings_action.triggered.connect(self.open_settings_dialog)
-            settings_menu.addAction(settings_action)
+            tools_menu.addAction(settings_action)
+            app_logger.debug(f"Added Opções action to Ferramentas menu: {settings_action.text()}")
 
+            # Ajuda menu
             help_menu = menu_bar.addMenu("Ajuda")
             help_action = QAction(QIcon("assets/icons/help.png"), "Ajuda Online...", self)
             help_action.triggered.connect(self.open_help_link)
             help_menu.addAction(help_action)
-            help_menu.addSeparator()
             about_action = QAction(QIcon("assets/icons/about.png"), "Sobre", self)
             about_action.triggered.connect(self.show_about)
             help_menu.addAction(about_action)
+
+            layout.setMenuBar(menu_bar)
 
             layout.setMenuBar(menu_bar)
 
@@ -622,41 +629,52 @@ class MainWindow(QWidget):
             debug_logger.debug(f"Help link error: {str(e)}")
 
     def show_about(self) -> None:
-        """Display an About dialog with the application logo, name, and version."""
-        dialog = QDialog(self)
-        dialog.setWindowTitle("Sobre")
-        dialog.setMinimumSize(300, 250)
-        dialog.setObjectName("AboutDialog")
+        """Display an About dialog with the application logo, name, version, and developer info."""
 
-        layout = QVBoxLayout()
-        layout.setAlignment(Qt.AlignCenter)
-        layout.setSpacing(8)
+        class AboutDialog(QDialog):
+            def __init__(self, parent=None):
+                super().__init__(parent)
+                self.setWindowTitle("Sobre")
+                self.setMinimumSize(300, 250)
+                self.setObjectName("AboutDialog")
 
-        logo = QLabel()
-        pixmap = QPixmap("assets/images/splash.png")
-        logo.setPixmap(pixmap.scaledToWidth(120, Qt.SmoothTransformation))
-        logo.setAlignment(Qt.AlignCenter)
-        logo.setObjectName("AboutLogo")
+                layout = QVBoxLayout()
+                layout.setAlignment(Qt.AlignCenter)
+                layout.setSpacing(8)
 
-        name_label = QLabel(APP_NAME)
-        name_label.setObjectName("AboutNameLabel")
-        name_label.setAlignment(Qt.AlignCenter)
+                logo = QLabel()
+                pixmap = QPixmap("assets/images/splash.png")
+                logo.setPixmap(pixmap.scaledToWidth(120, Qt.SmoothTransformation))
+                logo.setAlignment(Qt.AlignCenter)
+                logo.setObjectName("AboutLogo")
 
-        version_label = QLabel(f"Versão: {VERSION}")
-        version_label.setObjectName("AboutVersionLabel")
-        version_label.setAlignment(Qt.AlignCenter)
+                name_label = QLabel(APP_NAME)
+                name_label.setObjectName("AboutNameLabel")
+                name_label.setAlignment(Qt.AlignCenter)
 
-        layout.addWidget(logo)
-        layout.addSpacing(8)
-        layout.addWidget(name_label)
-        layout.addWidget(version_label)
+                version_label = QLabel(f"Versão: {VERSION}")
+                version_label.setObjectName("AboutVersionLabel")
+                version_label.setAlignment(Qt.AlignCenter)
 
-        button_box = QDialogButtonBox(QDialogButtonBox.Ok)
-        button_box.setObjectName("AboutButtonBox")
-        button_box.accepted.connect(dialog.accept)
-        layout.addWidget(button_box)
+                developer_label = QLabel("Developed by TechDev Andrade Ltda.")
+                developer_label.setObjectName("AboutVersionLabel")  # Reuse style for consistency
+                developer_label.setAlignment(Qt.AlignCenter)
 
-        dialog.setLayout(layout)
+                layout.addWidget(logo)
+                layout.addSpacing(8)
+                layout.addWidget(name_label)
+                layout.addWidget(version_label)
+                layout.addWidget(developer_label)
+
+                self.setLayout(layout)
+
+            def mousePressEvent(self, event):
+                """Close the dialog on any mouse click."""
+                if event.button() == Qt.LeftButton:
+                    self.accept()
+                super().mousePressEvent(event)
+
+        dialog = AboutDialog(self)
         dialog.exec_()
         app_logger.info("Showed About dialog")
         debug_logger.debug("About dialog displayed")


### PR DESCRIPTION
This pull request focuses on two main areas: updating the application's visual styling and enhancing the user interface functionality. The most significant changes include standardizing font usage across the application, improving the menu structure and labels, and enhancing the "About" dialog with developer information and interactivity.

### Styling Updates:
* Replaced `"Segoe UI Variable"` font with `"Segoe UI"` across all styles for consistency and compatibility. (`assets/styles/styles.qss`, multiple references: [[1]](diffhunk://#diff-19d7ed5ff66170e67191e93b537b1923edbb91aff6816169a9a386c4343ed7deL9-R54) [[2]](diffhunk://#diff-19d7ed5ff66170e67191e93b537b1923edbb91aff6816169a9a386c4343ed7deL68-R67) [[3]](diffhunk://#diff-19d7ed5ff66170e67191e93b537b1923edbb91aff6816169a9a386c4343ed7deL91-R90) etc.)
* Removed unused or redundant styling properties, such as box shadows and transition effects, to simplify the stylesheet. (`assets/styles/styles.qss`, references: [[1]](diffhunk://#diff-19d7ed5ff66170e67191e93b537b1923edbb91aff6816169a9a386c4343ed7deL9-R54) [[2]](diffhunk://#diff-19d7ed5ff66170e67191e93b537b1923edbb91aff6816169a9a386c4343ed7deL257-L262) [[3]](diffhunk://#diff-19d7ed5ff66170e67191e93b537b1923edbb91aff6816169a9a386c4343ed7deL284-L289)

### UI Enhancements:
* Improved menu structure by reorganizing items into clearer categories (e.g., splitting "Ferramentas" into "Editar" and "Ferramentas") and updating menu labels for clarity (e.g., adding ellipses to indicate actions that open dialogs). (`gui/main_window.py`, reference: [gui/main_window.pyR191-R236](diffhunk://#diff-c06f3750551501fc07ce1aff486fd8b3c26780da89363df5c05d118953ee8659R191-R236))
* Enhanced the "About" dialog to include developer information and made it interactive by allowing users to close it with a mouse click. (`gui/main_window.py`, references: [[1]](diffhunk://#diff-c06f3750551501fc07ce1aff486fd8b3c26780da89363df5c05d118953ee8659L625-R639) [[2]](diffhunk://#diff-c06f3750551501fc07ce1aff486fd8b3c26780da89363df5c05d118953ee8659R659-R677)