### PR TITLE
update tests; enhance test_main_window.py with exception handling for…

### DIFF
--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -163,11 +163,15 @@ class TestMainWindow(unittest.TestCase):
 
         event = MagicMock()
         event.button.return_value = Qt.LeftButton
-        status_bar.mousePressEvent(event)
+        try:
+            status_bar.mousePressEvent(event)
+        except Exception as e:
+            self.fail(f"mousePressEvent raised unexpected exception: {e}")
 
         status_bar.clicked.emit.assert_called_once()
         event.button.assert_called_once()
         status_bar.clicked.reset_mock()
+
     @patch("gui.main_window.is_model_downloaded")
     def test_main_window_update_transcription_button_state(self, mock_is_downloaded):
         """Test MainWindow.update_transcription_button_state updates button state."""
@@ -507,7 +511,6 @@ class TestMainWindow(unittest.TestCase):
         mock_open_file.assert_called_once()
         mock_dialog.assert_called_once()
         mock_dialog.return_value.exec_.assert_called_once()
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This pull request improves the robustness of test cases in `tests/test_main_window.py` by adding exception handling and includes a minor cleanup of unnecessary blank lines.

Enhancements to test cases:

* [`test_clickable_status_bar_mouse_press`](diffhunk://#diff-3621ee7104e308f89f8e6357d230a88d4fa6883ef75bf5c17657c9275ce47148R166-R174): Added a `try-except` block to ensure that any unexpected exceptions raised during the `mousePressEvent` are caught and reported as test failures. This improves test reliability and debugging clarity.

Code cleanup:

* Removed an unnecessary blank line at the end of the `test_main_window_show_summary_panel` method to maintain code consistency.… mousePressEvent and import ClickableStatusBar